### PR TITLE
Update v-slot popover sintax

### DIFF
--- a/popovers.md
+++ b/popovers.md
@@ -146,8 +146,7 @@ For our example, we'll create a slot with the name of `"todo-row"`. For our bene
     is-double-paned>
     <!--===============TODO ROW SLOT==============-->
     <div
-      slot='todo-row'
-      slot-scope='{ customData }'
+      #todo-row="{ customData }"
       class='todo-row'>
       <!--Todo content-->
       <div class='todo-content'>


### PR DESCRIPTION
To support Vue 3, and prevent eslint/tslint yell at you due deprecated features like console image below
```
error    `slot` attributes are deprecated    vue/no-deprecated-slot-attribute
error    `slot-scope` are deprecated      vue/no-deprecated-slot-scope-attribute
``